### PR TITLE
Remove explicit static argument from dsp56kEmu add_library

### DIFF
--- a/source/dsp56kEmu/CMakeLists.txt
+++ b/source/dsp56kEmu/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 project(dsp56kEmu)
 
-add_library(dsp56kEmu STATIC)
+add_library(dsp56kEmu)
 
 set(SOURCES
 aar.h


### PR DESCRIPTION
add_library defaults to creating static libraries. Removing the explicit "STATIC", one can override during cmake config time to build shared libraries with -DBUILD_SHARED_LIBS=true.